### PR TITLE
pandoc parameter rename

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ pdf:
 	pandoc \
 	  -o Unix_Shell_Handout.pdf \
           --toc \
-	   --latex-engine xelatex \
+	   --pdf-engine xelatex \
 	   --variable mainfont="DejaVu Sans" \
 	   --variable sansfont="DejaVu Sans" \
 	   -V geometry:"top=2cm, bottom=2.0cm, left=2.5cm, right=2.5cm" \
@@ -11,7 +11,7 @@ pdf:
 	pandoc \
 	  -o Unix_Shell_cheat_sheet.pdf \
            --toc \
-	   --latex-engine xelatex \
+	   --pdf-engine xelatex \
 	   --variable mainfont="DejaVu Sans" \
 	   --variable sansfont="DejaVu Sans" \
 	   -V geometry:"top=2cm, bottom=2.0cm, left=2.5cm, right=2.5cm" \


### PR DESCRIPTION
In version 2.0 of `pandoc` the parameter `--latex-engine` was renamed to `--pdf-engine` (https://pandoc.org/releases.html#behavior-changes-1). This change fixes the resulting error produced by recent `pandoc` versions.